### PR TITLE
Makes callback error a warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   'extends': 'standard',
   'rules': {
     'semi': ['error', 'always'],
-    'no-unused-vars': ['error', { 'varsIgnorePattern': 'apos', 'args': 'none', 'ignoreRestSiblings': true }]
+    'no-unused-vars': ['error', { 'varsIgnorePattern': 'apos', 'args': 'none', 'ignoreRestSiblings': true }],
+    'standard/no-callback-literal': 'warn'
   }
 };


### PR DESCRIPTION
Talked to Tom and he explained how a string in a callback might be appropriate at times. We can either count on `eslint-ignore` each of these cases or change to a warning instead of error for future Travis'ing.